### PR TITLE
add support for sec-websocket-protocol options

### DIFF
--- a/lib/async/websocket/server.rb
+++ b/lib/async/websocket/server.rb
@@ -23,13 +23,13 @@ require_relative 'connection'
 module Async
 	module WebSocket
 		class Server < Connection
-			def initialize(env, socket)
+			def initialize(env, socket, options)
 				scheme = env['rack.url_scheme'] == 'https' ? 'wss' : 'ws'
 				@url = "#{scheme}://#{env['HTTP_HOST']}#{env['REQUEST_URI']}"
 				
 				@env = env
 				
-				super socket, ::WebSocket::Driver.rack(self)
+				super socket, ::WebSocket::Driver.rack(self, options)
 			end
 			
 			attr :env
@@ -37,7 +37,7 @@ module Async
 			
 			HIJACK_RESPONSE = [-1, {}, []].freeze
 			
-			def self.open(env)
+			def self.open(env, options = {})
 				if ::WebSocket::Driver.websocket?(env)
 					return nil unless env['rack.hijack?']
 					
@@ -46,7 +46,7 @@ module Async
 						env['rack.hijack'].call
 					)
 					
-					connection = self.new(env, peer)
+					connection = self.new(env, peer, options)
 					
 					return connection unless block_given?
 					

--- a/spec/async/websocket/connection_spec.rb
+++ b/spec/async/websocket/connection_spec.rb
@@ -29,7 +29,7 @@ require 'async/http/url_endpoint'
 RSpec.describe Async::WebSocket::Connection, timeout: 5 do
 	include_context Async::RSpec::Reactor
 	
-	let(:server_address) {Async::HTTP::URLEndpoint.parse("http://localhost:9000")}
+	let(:server_address) {Async::HTTP::URLEndpoint.parse("http://localhost:9000", :reuse_port => true)}
 	let(:app) {Rack::Builder.parse_file(File.expand_path('../connection_spec.ru', __FILE__)).first}
 	let(:server) {Falcon::Server.new(Falcon::Server.middleware(app, verbose: true), server_address)}
 
@@ -51,6 +51,17 @@ RSpec.describe Async::WebSocket::Connection, timeout: 5 do
 		end
 		
 		expect(events.size).to be > 0
+		
+		server_task.stop
+	end
+
+        it "should send back Sec-WebScoket-Protocol header" do
+		server_task = reactor.async do
+			server.run
+		end
+		
+		# Should send and receive Sec-WebScoket-Protocol header as
+		# `ws`
 		
 		server_task.stop
 	end

--- a/spec/async/websocket/connection_spec.ru
+++ b/spec/async/websocket/connection_spec.ru
@@ -7,7 +7,7 @@ class Upgrade
 	end
 	
 	def call(env)
-		result = Async::WebSocket::Server.open(env) do |server|
+		result = Async::WebSocket::Server.open(env, :protocols => %w[ws]) do |server|
 			read, write = IO.pipe
 			
 			Process.spawn("ls -lah", :out => write)


### PR DESCRIPTION
As discussed in issue #1, add support for options to `Async::WebSocket::Server.open`