### PR TITLE
Async::WebSocket::Incoming initial implementation

### DIFF
--- a/lib/async/websocket/incoming.rb
+++ b/lib/async/websocket/incoming.rb
@@ -1,0 +1,47 @@
+require_relative "connection"
+
+module Async
+	module WebSocket
+		class Incoming < Connection
+			def initialize(request)
+				@env = build_env(request)
+				@url = build_url(request)
+
+				super hijacked_io(request), ::WebSocket::Driver.rack(self)
+			end
+
+			attr :env
+			attr :url
+
+			protected
+
+			def build_env(request)
+				{
+					"HTTP_CONNECTION" => request.headers["connection"].to_s,
+					"HTTP_HOST" => request.headers["host"].to_s,
+					"HTTP_ORIGIN" => request.headers["origin"].to_s,
+					"HTTP_SEC_WEBSOCKET_EXTENSIONS" => request.headers["sec-websocket-extensions"].to_s,
+					"HTTP_SEC_WEBSOCKET_KEY" => request.headers["sec-websocket-key"].to_s,
+					"HTTP_SEC_WEBSOCKET_KEY1" => request.headers["sec-websocket-key1"].to_s,
+					"HTTP_SEC_WEBSOCKET_KEY2" => request.headers["sec-websocket-key2"].to_s,
+					"HTTP_SEC_WEBSOCKET_PROTOCOL" => request.headers["sec-websocket-protocol"].to_s,
+					"HTTP_SEC_WEBSOCKET_VERSION" => request.headers["sec-websocket-version"].to_s,
+					"HTTP_UPGRADE" => request.headers["upgrade"].to_s,
+					"REQUEST_METHOD" => request.method,
+					"rack.input" => request.body
+				}
+			end
+
+			def build_url(request)
+				"#{request.scheme}://#{request.authority}#{request.path}"
+			end
+
+			def hijacked_io(request)
+				wrapper = request.hijack
+				io = Async::IO.try_convert(wrapper.io.dup)
+				wrapper.close
+				io
+			end
+		end
+	end
+end


### PR DESCRIPTION
@ioquatix Here's the prototype for what I was proposing a few days ago. Allows WebSocket connections to be created directly from an `Async::HTTP::Request`:

```ruby
Async.run do
  Async::HTTP::Server.for(endpoint, protocol) { |request|
    if socket = Async::WebSocket::Incoming.new(request)
      # we have an open socket
    end
  }.run
end
```

I intentionally left out checking whether the request is a valid WebSocket request and can be hijacked. The approach I like the most is for `initialize` to do this and raise an exception:

```ruby
def initialize(request)
  @env = build_env(request)
  @url = build_url(request)

  if request.hijack? && websocket?(@env)
    super hijacked_io(request), ::WebSocket::Driver.rack(self)
  else
    raise InvalidConnection
  end
end

def websocket?(env)
  ::WebSocket::Driver.websocket?(env)
end
```

Could alternatively use the `self.open` approach from `Async::WebSocket::Server` but I prefer the explicitness of an exception rather than a more implicit `nil` check. In my case, I want to handle invalid connection attempts by explicitly returning a bad request--the exception makes it more clear.

```ruby
# explicit exception 
#
class WebSocket
  def initialize(connection)
    @socket = Async::WebSocket::Incoming.new(connection.request)
    # ...
  rescue Async::WebSocket::InvalidConnection
    # handle
  ensure
    @socket&.close
  end
end

# nil check
#
class WebSocket
  def initialize(connection)
    if socket = Async::WebSocket::Incoming.new(connection.request)
      # ...
    else
      # handle
    end
  ensure
    socket.close
  end
end
```

Since this mostly comes down to preference, I'll defer to you on this.