### PR TITLE
Release connection to pool on connect error

### DIFF
--- a/lib/async/websocket/client.rb
+++ b/lib/async/websocket/client.rb
@@ -96,6 +96,7 @@ module Async
 				response = request.call(connection)
 				
 				unless response.stream?
+					pool.release(connection)
 					raise ProtocolError, "Failed to negotiate connection: #{response.status}"
 				end
 				


### PR DESCRIPTION
Fix issue where connecting to websocket server that returns request
error will hang waiting for connection pool to drain.