### PR TITLE
Make protocol upgrade case-insensitive

### DIFF
--- a/lib/async/websocket/adapters/http.rb
+++ b/lib/async/websocket/adapters/http.rb
@@ -30,11 +30,11 @@ module Async
 				include ::Protocol::WebSocket::Headers
 				
 				def self.websocket?(request)
-					Array(request.protocol).include?(PROTOCOL)
+					Array(request.protocol).any? { |e| e.casecmp?(PROTOCOL) }
 				end
 				
 				def self.open(request, headers: [], protocols: [], handler: Connection, **options, &block)
-					if Array(request.protocol).include?(PROTOCOL)
+					if websocket?(request)
 						# Select websocket sub-protocol:
 						if requested_protocol = request.headers[SEC_WEBSOCKET_PROTOCOL]
 							protocol = (requested_protocol & protocols).first


### PR DESCRIPTION
## Description

Some clients/servers don't send the protocol upgrade header as exactly "websocket", and instead send it as for example "WebSocket".

This is allowed according to https://github.com/httpwg/http-core/pull/131 so it probably should be supported even if we never send it.

### Types of Changes

- Bug fix.

### Testing

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
