### PR TITLE
CI: Avoid 3.0 -> "3" in YAML

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,7 +17,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         
         experimental: [false]
         env: [""]


### PR DESCRIPTION
## Description

This avoids the issue in https://github.com/actions/runner/issues/849 

### Types of Changes

- Maintenance.

Looks like this after the change:

<img width="543" alt="bild" src="https://user-images.githubusercontent.com/211/121011990-89c04380-c797-11eb-90cf-e03f960e9464.png">

Before, it looked like:

<img width="538" alt="bild" src="https://user-images.githubusercontent.com/211/121012109-ab212f80-c797-11eb-8021-8d71440381b7.png">



### Testing

