### PR TITLE
CI: Set JRUBY_OPTS=-X+O to enable "ObjectSpace"

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -29,6 +29,7 @@ jobs:
           - os: ubuntu
             ruby: jruby
             experimental: true
+            env: JRUBY_OPTS="-X+O"
           - os: ubuntu
             ruby: head
             experimental: true


### PR DESCRIPTION
## Description

This PR enables a JRuby feature:

    ObjectSpace is disabled; each_object will only work with Class, pass -X+O to enable

With this ENV variable in the build, the warning is not emitted.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.
- Performance improvement.
- Maintenance.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
