### PR TITLE
Ensure the client is closed when closing the connection.

### DIFF
--- a/test/async/websocket/client.rb
+++ b/test/async/websocket/client.rb
@@ -1,0 +1,37 @@
+
+
+ClientExamples = Sus::Shared("a websocket client") do
+	include Sus::Fixtures::Async::HTTP::ServerContext
+	
+	let(:app) do
+		Protocol::HTTP::Middleware.for do |request|
+			Async::WebSocket::Adapters::HTTP.open(request) do |connection|
+				while message = connection.read
+					connection.write(message)
+				end
+				
+				connection.close
+			end or Protocol::HTTP::Response[404, {}, []]
+		end
+	end
+	
+	let(:timeout) {nil}
+	
+	it "can connect to a websocket server and close underlying client" do
+		connection = Async::WebSocket::Client.connect(client_endpoint)
+		connection.send_text("Hello World!")
+		message = connection.read
+		expect(message.to_str).to be == "Hello World!"
+		connection.close
+	end
+end
+
+describe Async::WebSocket::Client do
+	with "h1", protocol: Async::HTTP::Protocol::HTTP1 do
+		it_behaves_like ClientExamples
+	end
+
+	with "h2", protocol: Async::HTTP::Protocol::HTTP2 do
+		it_behaves_like ClientExamples
+	end
+end

--- a/test/async/websocket/server.rb
+++ b/test/async/websocket/server.rb
@@ -11,7 +11,7 @@ require 'async/websocket/adapters/http'
 
 require 'sus/fixtures/async/http/server_context'
 
-WebSocketServerExamples = Sus::Shared('a websocket server') do
+ServerExamples = Sus::Shared('a websocket server') do
 	include Sus::Fixtures::Async::HTTP::ServerContext
 	
 	let(:message) {"Hello World"}
@@ -72,11 +72,11 @@ end
 describe Async::HTTP::Protocol::HTTP1 do
 	let(:protocol) {subject}
 	
-	it_behaves_like WebSocketServerExamples
+	it_behaves_like ServerExamples
 end
 
 describe Async::HTTP::Protocol::HTTP2 do
 	let(:protocol) {subject}
 	
-	it_behaves_like WebSocketServerExamples
+	it_behaves_like ServerExamples
 end


### PR DESCRIPTION
When returning a single connection object, decorate it so that calling close also closes the underlying client.

Fixes #46.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
