### PR TITLE
improve checks in `stream?` for http1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,3 @@
 Juan Antonio Martín Lucas <dev@jaml.pro>
 Aurora Nockert <aurora@aventine.se>
+Thomas Morgan <tm@iprog.com>

--- a/lib/async/websocket/upgrade_request.rb
+++ b/lib/async/websocket/upgrade_request.rb
@@ -20,9 +20,10 @@ module Async
 			include ::Protocol::WebSocket::Headers
 			
 			class Wrapper
-				def initialize(response)
+				def initialize(response, verified:)
 					@response = response
 					@stream = nil
+					@verified = verified
 				end
 				
 				def close
@@ -32,7 +33,7 @@ module Async
 				attr_accessor :response
 				
 				def stream?
-					@response.status == 101
+					@response.status == 101 && @verified
 				end
 				
 				def status
@@ -74,7 +75,7 @@ module Async
 					end
 				end
 				
-				return Wrapper.new(response)
+				return Wrapper.new(response, verified: !!accept_digest)
 			end
 		end
 	end


### PR DESCRIPTION
This PR tightens up the check in `stream?` for HTTP/1.1 requests by ensuring the `sec-websocket-accept` header was verified in addition to `status == 101`.

#### Before
```
Status not 101       : `stream?` => false
101 w/missing header : `stream?` => true
Bad header           : raises exception
```

#### After
```
Status not 101       : `stream?` => false
101 w/missing header : `stream?` => false
Bad header           : raises exception
```

#### Reference
[RFC 6455](https://www.rfc-editor.org/rfc/rfc6455.html#page-19), near the end of section 4.1, says that a WS connection must be failed if the header is missing or invalid (in point (4),  at the bottom of page 19).


## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
