### PR TITLE
Improve validation of Websocket requests

### DIFF
--- a/lib/async/websocket/connect_request.rb
+++ b/lib/async/websocket/connect_request.rb
@@ -12,7 +12,7 @@ require 'async/variable'
 
 module Async
 	module WebSocket
-		# This is required for HTTP/1.x to upgrade the connection to the WebSocket protocol.
+		# This is required for HTTP/2 to establish a connection using the WebSocket protocol.
 		# See https://tools.ietf.org/html/rfc8441 for more details.
 		class ConnectRequest < ::Protocol::HTTP::Request
 			include ::Protocol::WebSocket::Headers

--- a/lib/async/websocket/upgrade_request.rb
+++ b/lib/async/websocket/upgrade_request.rb
@@ -17,6 +17,7 @@ require_relative 'error'
 module Async
 	module WebSocket
 		# This is required for HTTP/1.x to upgrade the connection to the WebSocket protocol.
+		# See https://tools.ietf.org/html/rfc6455
 		class UpgradeRequest < ::Protocol::HTTP::Request
 			include ::Protocol::WebSocket::Headers
 			
@@ -75,8 +76,9 @@ module Async
 						raise ProtocolError, "Invalid accept digest, expected #{expected_accept_digest.inspect}, got #{accept_digest.inspect}!"
 					end
 				end
+				verified = accept_digest && Array(response.protocol) == %w(websocket) && response.headers['connection']&.include?('upgrade')
 				
-				return Wrapper.new(response, verified: !!accept_digest)
+				return Wrapper.new(response, verified: verified)
 			end
 		end
 	end

--- a/test/async/websocket/client.rb
+++ b/test/async/websocket/client.rb
@@ -186,5 +186,15 @@ describe Async::WebSocket::Client do
 	with 'http/2' do
 		let(:protocol) {Async::HTTP::Protocol::HTTP2}
 		it_behaves_like ClientExamples
+		
+		with 'invalid status' do
+			let(:app) do
+				Protocol::HTTP::Middleware.for do |request|
+					Protocol::HTTP::Response[403, {}, []]
+				end
+			end
+			
+			it_behaves_like FailedToNegotiate
+		end
 	end
 end

--- a/test/async/websocket/client.rb
+++ b/test/async/websocket/client.rb
@@ -105,6 +105,14 @@ ClientExamples = Sus::Shared("a websocket client") do
 	end
 end
 
+FailedToNegotiate = Sus::Shared("a failed websocket request") do
+	it 'raises an error' do
+		expect do
+			Async::WebSocket::Client.connect(client_endpoint) {}
+		end.to raise_exception(Async::WebSocket::ProtocolError, message: be =~ /Failed to negotiate connection/)
+	end
+end
+
 describe Async::WebSocket::Client do
 	include Sus::Fixtures::Async::HTTP::ServerContext
 
@@ -112,10 +120,38 @@ describe Async::WebSocket::Client do
 		let(:protocol) {Async::HTTP::Protocol::HTTP1}
 		it_behaves_like ClientExamples
 		
+		def valid_headers(request)
+			{
+				'connection' => 'upgrade',
+				'upgrade' => 'websocket',
+				'sec-websocket-accept' => Protocol::WebSocket::Headers::Nounce.accept_digest(request.headers['sec-websocket-key'].first)
+			}
+		end
+		
+		with 'invalid connection header' do
+			let(:app) do
+				Protocol::HTTP::Middleware.for do |request|
+					Protocol::HTTP::Response[101, valid_headers(request).except('connection'), []]
+				end
+			end
+			
+			it_behaves_like FailedToNegotiate
+		end
+		
+		with 'invalid upgrade header' do
+			let(:app) do
+				Protocol::HTTP::Middleware.for do |request|
+					Protocol::HTTP::Response[101, valid_headers(request).except('upgrade'), []]
+				end
+			end
+			
+			it_behaves_like FailedToNegotiate
+		end
+		
 		with 'invalid sec-websocket-accept header' do
 			let(:app) do
 				Protocol::HTTP::Middleware.for do |request|
-					Protocol::HTTP::Response[101, {'sec-websocket-accept'=>'wrong-digest'}, []]
+					Protocol::HTTP::Response[101, valid_headers(request).merge('sec-websocket-accept'=>'wrong-digest'), []]
 				end
 			end
 			
@@ -125,19 +161,25 @@ describe Async::WebSocket::Client do
 				end.to raise_exception(Async::WebSocket::ProtocolError, message: be =~ /Invalid accept digest/)
 			end
 		end
-			
+		
 		with 'missing sec-websocket-accept header' do
 			let(:app) do
 				Protocol::HTTP::Middleware.for do |request|
-					Protocol::HTTP::Response[101, {}, []]
+					Protocol::HTTP::Response[101, valid_headers(request).except('sec-websocket-accept'), []]
 				end
 			end
 			
-			it 'raises an error' do
-				expect do
-					Async::WebSocket::Client.connect(client_endpoint) {}
-				end.to raise_exception(Async::WebSocket::ProtocolError, message: be =~ /Failed to negotiate connection/)
+			it_behaves_like FailedToNegotiate
+		end
+		
+		with 'invalid status' do
+			let(:app) do
+				Protocol::HTTP::Middleware.for do |request|
+					Protocol::HTTP::Response[403, valid_headers(request), []]
+				end
 			end
+			
+			it_behaves_like FailedToNegotiate
 		end
 	end
 	


### PR DESCRIPTION
This PR improves the validation of Websocket requests to:

* Verify `response.protocol` (aka `Upgrade`) for h11
* Verify `Connection` for h11

It also adds tests for the existing verification of `response.status` for both h11 and h2.

This is based on [RFC 6455](https://www.rfc-editor.org/rfc/rfc6455.html#page-19), page 19, items 2 (Upgrade) and 3 (Connection).

## Types of Changes

- Performance improvement.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
