### PR TITLE
Ensure h2 Websocket requests include :scheme

### DIFF
--- a/lib/async/websocket/client.rb
+++ b/lib/async/websocket/client.rb
@@ -90,14 +90,14 @@ module Async
 				end
 			end
 			
-			def connect(authority, path, headers: nil, handler: Connection, extensions: ::Protocol::WebSocket::Extensions::Client.default, **options, &block)
+			def connect(authority, path, scheme: @delegate.scheme, headers: nil, handler: Connection, extensions: ::Protocol::WebSocket::Extensions::Client.default, **options, &block)
 				headers = ::Protocol::HTTP::Headers[headers]
 				
 				extensions&.offer do |extension|
 					headers.add(SEC_WEBSOCKET_EXTENSIONS, extension.join("; "))
 				end
 				
-				request = Request.new(nil, authority, path, headers, **options)
+				request = Request.new(scheme, authority, path, headers, **options)
 				
 				pool = @delegate.pool
 				connection = pool.acquire


### PR DESCRIPTION
This PR causes `:scheme` to be properly populated for http2 Websocket requests.

`:scheme` is presently showing up to the server as an empty string (which is odd, since I'd expect it to be `nil` instead--I did not chase this down).

According to [RFC 8441, section 4](https://www.rfc-editor.org/rfc/rfc8441#section-4), bullet 2, `:scheme` must be present for h2 WS requests (which contrasts to other uses of h2 `CONNECT`, where `:scheme` is expected to be omitted).

This also adds tests for the presence and validity of `authority`, `path`, and `protocol`.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
