### PR TITLE
Fix ruby unused variable warning

### DIFF
--- a/lib/async/websocket/upgrade_response.rb
+++ b/lib/async/websocket/upgrade_response.rb
@@ -18,7 +18,6 @@ module Async
 				
 				if accept_nounce = request.headers[SEC_WEBSOCKET_KEY]&.first
 					headers.add(SEC_WEBSOCKET_ACCEPT, Nounce.accept_digest(accept_nounce))
-					status = 101
 					
 					if protocol
 						headers.add(SEC_WEBSOCKET_PROTOCOL, protocol)


### PR DESCRIPTION
Fixes warning:
```
.../lib/async/websocket/upgrade_response.rb:21: warning: assigned but unused variable - status
```

## Types of Changes

- Maintenance.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
