### PR TITLE
Fix arguments to 404 response

### DIFF
--- a/lib/async/websocket/adapters/rails.rb
+++ b/lib/async/websocket/adapters/rails.rb
@@ -13,7 +13,7 @@ module Async
 					if response = Rack.open(request.env, **options, &block)
 						::Rack::Response[*response]
 					else
-						::ActionDispatch::Response.new(404, [], [])
+						::ActionDispatch::Response.new(404)
 					end
 				end
 			end


### PR DESCRIPTION
## Types of Changes

- Bug fix.

## Contribution
The second argument is the headers field, and it's actually a hash type. Sending an empty array breaks parsing further down the line when trying to look up hash values by key. This change just lets the default argument values be used.

See: https://github.com/rails/rails/blob/c80fa6a0697656a522b7688d116a9a6fca1fc0fd/actionpack/lib/action_dispatch/http/response.rb#L169

Stacktrace:
<img width="615" alt="image" src="https://github.com/socketry/async-websocket/assets/1386547/d94c41ff-e01b-43f2-8d1a-af0a6a951379">


<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
